### PR TITLE
Hyddwn Launcher v1.0.2

### DIFF
--- a/HyddwnLauncher/Network/NexonApi.cs
+++ b/HyddwnLauncher/Network/NexonApi.cs
@@ -448,7 +448,16 @@ namespace HyddwnLauncher.Network
 
             var response = await request.ExecutePut<string>();
 
-            return response.StatusCode != HttpStatusCode.BadRequest;
+            if (response.StatusCode != HttpStatusCode.BadRequest)
+                return true;
+
+            var data = await response.GetContent();
+            var responseObject = JsonConvert.DeserializeObject<ErrorResponse>(data);
+            Log.Info("Failed code verification. Code: {0} | Description: {1}", responseObject.Code,
+                responseObject.Description);
+
+
+            return false;
         }
 
         private void StartAccessTokenExpiryTimer(int timeout = 7200)

--- a/HyddwnLauncher/Network/NexonApi.cs
+++ b/HyddwnLauncher/Network/NexonApi.cs
@@ -344,7 +344,8 @@ namespace HyddwnLauncher.Network
 
             try
             {
-                WebServer.Instance.Stop();
+                if (App.IsAdministrator() && LauncherContext.Instance.LauncherSettingsManager.LauncherSettings.EnableCaptchaBypass)
+                    WebServer.Instance.Stop();
             }
             catch (Exception ex)
             {

--- a/HyddwnLauncher/Properties/AssemblyInfo.cs
+++ b/HyddwnLauncher/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/HyddwnLauncher/Properties/AssemblyInfo.cs
+++ b/HyddwnLauncher/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]


### PR DESCRIPTION
Introduces two small patches:

* Fixes `WebServer.Stop()` being called in a situation where it would not have been started, resulting in an exception.
* Errors were supported to be logged for the verify endpoint but I believe I lost the changes so they were never released.