### PR TITLE
Fixes a rare exception in `WriteAllTextWithBackup()`

### DIFF
--- a/HyddwnLauncher/Properties/AssemblyInfo.cs
+++ b/HyddwnLauncher/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]

--- a/HyddwnLauncher/Util/Extentions.cs
+++ b/HyddwnLauncher/Util/Extentions.cs
@@ -296,8 +296,8 @@ namespace HyddwnLauncher.Util
                 return;
             }
 
-            // generate a temp filename
-            var tempPath = Path.GetTempFileName();
+            // use the same folder so that they are always on the same drive!
+            var tempPath = Path.Combine(Path.GetDirectoryName(path), Guid.NewGuid().ToString());
 
             // create the backup name
             var backup = path + ".backup";


### PR DESCRIPTION
* Fixes the occurance of `ERROR_UNABLE_TO_MOVE_REPLACEMENT` under certain conditions.